### PR TITLE
[BAEL-2278] | spring-5-reactive |  extra changes - assembling flux only on FooService

### DIFF
--- a/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/service/FooNameHelper.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/service/FooNameHelper.java
@@ -4,42 +4,35 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import com.baeldung.debugging.consumer.model.Foo;
 
-import reactor.core.publisher.Flux;
-
 public class FooNameHelper {
 
-    public static Flux<Foo> concatAndSubstringFooName(Flux<Foo> flux) {
-        flux = concatFooName(flux);
-        flux = substringFooName(flux);
-        return flux;
+    public static Foo concatAndSubstringFooName(Foo foo) {
+        concatFooName(foo);
+        substringFooName(foo);
+        return foo;
     }
 
-    public static Flux<Foo> concatFooName(Flux<Foo> flux) {
-        flux = flux.map(foo -> {
-            String processedName = null;
-            Integer random = ThreadLocalRandom.current()
-                .nextInt(0, 80);
-            processedName = (random != 0) ? foo.getFormattedName() : foo.getFormattedName() + "-bael";
-            foo.setFormattedName(processedName);
-            return foo;
-        });
-        return flux;
+    public static Foo concatFooName(Foo foo) {
+        String processedName = null;
+        Integer random = ThreadLocalRandom.current()
+            .nextInt(0, 80);
+        processedName = (random != 0) ? foo.getFormattedName() : foo.getFormattedName() + "-bael";
+        foo.setFormattedName(processedName);
+        return foo;
     }
 
-    public static Flux<Foo> substringFooName(Flux<Foo> flux) {
-        return flux.map(foo -> {
-            String processedName;
-            Integer random = ThreadLocalRandom.current()
-                .nextInt(0, 100);
+    public static Foo substringFooName(Foo foo) {
+        String processedName;
+        Integer random = ThreadLocalRandom.current()
+            .nextInt(0, 100);
 
-            processedName = (random == 0) ? foo.getFormattedName()
-                .substring(10, 15)
-                : foo.getFormattedName()
-                    .substring(0, 5);
+        processedName = (random == 0) ? foo.getFormattedName()
+            .substring(10, 15)
+            : foo.getFormattedName()
+                .substring(0, 5);
 
-            foo.setFormattedName(processedName);
-            return foo;
-        });
+        foo.setFormattedName(processedName);
+        return foo;
     }
 
 }

--- a/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/service/FooQuantityHelper.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/service/FooQuantityHelper.java
@@ -4,28 +4,22 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import com.baeldung.debugging.consumer.model.Foo;
 
-import reactor.core.publisher.Flux;
-
 public class FooQuantityHelper {
 
-    public static Flux<Foo> processFooReducingQuantity(Flux<Foo> flux) {
-        flux = flux.map(foo -> {
-            Integer result;
-            Integer random = ThreadLocalRandom.current()
-                .nextInt(0, 90);
-            result = (random == 0) ? result = 0 : foo.getQuantity() + 2;
-            foo.setQuantity(result);
-            return foo;
-        });
-        return divideFooQuantity(flux);
+    public static Foo processFooReducingQuantity(Foo foo) {
+
+        Integer result;
+        Integer random = ThreadLocalRandom.current()
+            .nextInt(0, 90);
+        result = (random == 0) ? result = 0 : foo.getQuantity() + 2;
+        foo.setQuantity(result);
+        return divideFooQuantity(foo);
     }
 
-    public static Flux<Foo> divideFooQuantity(Flux<Foo> flux) {
-        return flux.map(foo -> {
-            Integer result = Math.round(5 / foo.getQuantity());
-            foo.setQuantity(result);
-            return foo;
-        });
+    public static Foo divideFooQuantity(Foo foo) {
+        Integer result = Math.round(5 / foo.getQuantity());
+        foo.setQuantity(result);
+        return foo;
     }
 
 }

--- a/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/service/FooReporter.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/service/FooReporter.java
@@ -5,22 +5,18 @@ import org.slf4j.LoggerFactory;
 
 import com.baeldung.debugging.consumer.model.Foo;
 
-import reactor.core.publisher.Flux;
-
 public class FooReporter {
 
     private static Logger logger = LoggerFactory.getLogger(FooReporter.class);
 
-    public static Flux<Foo> reportResult(Flux<Foo> input, String approach) {
-        return input.map(foo -> {
-            if (foo.getId() == null)
-                throw new IllegalArgumentException("Null id is not valid!");
-            logger.info("Reporting for approach {}: Foo with id '{}' name '{}' and quantity '{}'", approach, foo.getId(), foo.getFormattedName(), foo.getQuantity());
-            return foo;
-        });
+    public static Foo reportResult(Foo foo, String approach) {
+        if (foo.getId() == null)
+            throw new IllegalArgumentException("Null id is not valid!");
+        logger.info("Reporting for approach {}: Foo with id '{}' name '{}' and quantity '{}'", approach, foo.getId(), foo.getFormattedName(), foo.getQuantity());
+        return foo;
     }
 
-    public static Flux<Foo> reportResult(Flux<Foo> input) {
+    public static Foo reportResult(Foo input) {
         return reportResult(input, "default");
     }
 }

--- a/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/service/FooService.java
+++ b/spring-5-reactive/src/main/java/com/baeldung/debugging/consumer/service/FooService.java
@@ -1,11 +1,5 @@
 package com.baeldung.debugging.consumer.service;
 
-import static com.baeldung.debugging.consumer.service.FooNameHelper.concatAndSubstringFooName;
-import static com.baeldung.debugging.consumer.service.FooNameHelper.substringFooName;
-import static com.baeldung.debugging.consumer.service.FooQuantityHelper.divideFooQuantity;
-import static com.baeldung.debugging.consumer.service.FooQuantityHelper.processFooReducingQuantity;
-import static com.baeldung.debugging.consumer.service.FooReporter.reportResult;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -21,100 +15,107 @@ public class FooService {
     private static Logger logger = LoggerFactory.getLogger(FooService.class);
 
     public void processFoo(Flux<Foo> flux) {
-        flux = FooNameHelper.concatFooName(flux);
-        flux = FooNameHelper.substringFooName(flux);
-        flux = flux.log();
-        flux = FooReporter.reportResult(flux);
-        flux = flux.doOnError(error -> {
-            logger.error("The following error happened on processFoo method!", error);
-        });
-        flux.subscribe();
+        flux.map(FooNameHelper::concatFooName)
+            .map(FooNameHelper::substringFooName)
+            .log()
+            .map(FooReporter::reportResult)
+            .doOnError(error -> {
+                logger.error("The following error happened on processFoo method!", error);
+            })
+            .subscribe();
     }
 
     public void processFooInAnotherScenario(Flux<Foo> flux) {
-        flux = FooNameHelper.substringFooName(flux);
-        flux = FooQuantityHelper.divideFooQuantity(flux);
-        flux.subscribe();
+        flux.map(FooNameHelper::substringFooName)
+            .map(FooQuantityHelper::divideFooQuantity)
+            .subscribe();
     }
 
     public void processUsingApproachOneWithErrorHandling(Flux<Foo> flux) {
         logger.info("starting approach one w error handling!");
-        flux = concatAndSubstringFooName(flux);
-        flux = concatAndSubstringFooName(flux);
-        flux = substringFooName(flux);
-        flux = processFooReducingQuantity(flux);
-        flux = processFooReducingQuantity(flux);
-        flux = processFooReducingQuantity(flux);
-        flux = reportResult(flux, "ONE w/ EH");
-        flux = flux.doOnError(error -> {
-            logger.error("Approach 1 with Error Handling failed!", error);
-        });
-        flux.subscribe();
+        flux.map(FooNameHelper::concatAndSubstringFooName)
+            .map(FooNameHelper::concatAndSubstringFooName)
+            .map(FooNameHelper::substringFooName)
+            .map(FooQuantityHelper::processFooReducingQuantity)
+            .map(FooQuantityHelper::processFooReducingQuantity)
+            .map(FooQuantityHelper::processFooReducingQuantity)
+            .map(foo -> FooReporter.reportResult(foo, "ONE w/ EH"))
+            .doOnError(error -> {
+                logger.error("Approach 1 with Error Handling failed!", error);
+            })
+            .subscribe();
     }
 
     public void processUsingApproachThree(Flux<Foo> flux) {
         logger.info("starting approach three!");
-        flux = concatAndSubstringFooName(flux);
-        flux = reportResult(flux, "THREE");
-        flux = flux.doOnError(error -> {
-            logger.error("Approach 3 failed!", error);
-        });
-        flux.subscribe();
+        flux.map(FooNameHelper::concatAndSubstringFooName)
+            .map(foo -> FooReporter.reportResult(foo, "THREE"))
+            .doOnError(error -> {
+                logger.error("Approach 3 failed!", error);
+            })
+            .subscribe();
     }
 
     public void processUsingApproachFourWithCheckpoint(Flux<Foo> flux) {
         logger.info("starting approach four!");
-        flux = concatAndSubstringFooName(flux);
-        flux = flux.checkpoint("CHECKPOINT 1");
-        flux = concatAndSubstringFooName(flux);
-        flux = divideFooQuantity(flux);
-        flux = flux.checkpoint("CHECKPOINT 2", true);
-        flux = reportResult(flux, "FOUR");
-        flux = concatAndSubstringFooName(flux).doOnError(error -> {
-            logger.error("Approach 4 failed!", error);
-        });
-        flux.subscribe();
+        flux.map(FooNameHelper::concatAndSubstringFooName)
+            .checkpoint("CHECKPOINT 1")
+            .map(FooNameHelper::concatAndSubstringFooName)
+            .map(FooQuantityHelper::divideFooQuantity)
+            .checkpoint("CHECKPOINT 2", true)
+            .map(foo -> FooReporter.reportResult(foo, "FOUR"))
+            .map(FooNameHelper::concatAndSubstringFooName)
+            .doOnError(error -> {
+                logger.error("Approach 4 failed!", error);
+            })
+            .subscribe();
     }
 
     public void processUsingApproachFourWithInitialCheckpoint(Flux<Foo> flux) {
         logger.info("starting approach four!");
-        flux = concatAndSubstringFooName(flux);
-        flux = flux.checkpoint("CHECKPOINT 1", true);
-        flux = concatAndSubstringFooName(flux);
-        flux = divideFooQuantity(flux);
-        flux = reportResult(flux, "FOUR");
-        flux = flux.doOnError(error -> {
-            logger.error("Approach 4-2 failed!", error);
-        });
-        flux.subscribe();
+        flux.map(FooNameHelper::concatAndSubstringFooName)
+            .checkpoint("CHECKPOINT 1", true)
+            .map(FooNameHelper::concatAndSubstringFooName)
+            .map(FooQuantityHelper::divideFooQuantity)
+            .map(foo -> FooReporter.reportResult(foo, "FOUR"))
+            .doOnError(error -> {
+                logger.error("Approach 4-2 failed!", error);
+            })
+            .subscribe();
     }
 
     public void processUsingApproachFivePublishingToDifferentParallelThreads(Flux<Foo> flux) {
         logger.info("starting approach five-parallel!");
-        flux = concatAndSubstringFooName(flux).publishOn(Schedulers.newParallel("five-parallel-foo"))
-            .log();
-        flux = concatAndSubstringFooName(flux);
-        flux = divideFooQuantity(flux);
-        flux = reportResult(flux, "FIVE-PARALLEL").publishOn(Schedulers.newSingle("five-parallel-bar"));
-        flux = concatAndSubstringFooName(flux).doOnError(error -> {
-            logger.error("Approach 5-parallel failed!", error);
-        });
-        flux.subscribeOn(Schedulers.newParallel("five-parallel-starter"))
+        flux.map(FooNameHelper::concatAndSubstringFooName)
+            .publishOn(Schedulers.newParallel("five-parallel-foo"))
+            .log()
+            .map(FooNameHelper::concatAndSubstringFooName)
+            .map(FooQuantityHelper::divideFooQuantity)
+            .map(foo -> FooReporter.reportResult(foo, "FIVE_PARALLEL"))
+            .publishOn(Schedulers.newSingle("five-parallel-bar"))
+            .map(FooNameHelper::concatAndSubstringFooName)
+            .doOnError(error -> {
+                logger.error("Approach 5-parallel failed!", error);
+            })
+            .subscribeOn(Schedulers.newParallel("five-parallel-starter"))
             .subscribe();
     }
 
     public void processUsingApproachFivePublishingToDifferentSingleThreads(Flux<Foo> flux) {
         logger.info("starting approach five-single!");
-        flux = flux.log()
-            .subscribeOn(Schedulers.newSingle("five-single-starter"));
-        flux = concatAndSubstringFooName(flux).publishOn(Schedulers.newSingle("five-single-foo"));
-        flux = concatAndSubstringFooName(flux);
-        flux = divideFooQuantity(flux);
-        flux = reportResult(flux, "FIVE-SINGLE").publishOn(Schedulers.newSingle("five-single-bar"));
-        flux = concatAndSubstringFooName(flux).doOnError(error -> {
-            logger.error("Approach 5-single failed!", error);
-        });
-        flux.subscribe();
+        flux.log()
+            .subscribeOn(Schedulers.newSingle("five-single-starter"))
+            .map(FooNameHelper::concatAndSubstringFooName)
+            .publishOn(Schedulers.newSingle("five-single-foo"))
+            .map(FooNameHelper::concatAndSubstringFooName)
+            .map(FooQuantityHelper::divideFooQuantity)
+            .map(foo -> FooReporter.reportResult(foo, "FIVE-SINGLE"))
+            .publishOn(Schedulers.newSingle("five-single-bar"))
+            .map(FooNameHelper::concatAndSubstringFooName)
+            .doOnError(error -> {
+                logger.error("Approach 5-single failed!", error);
+            })
+            .subscribe();
     }
 
 }


### PR DESCRIPTION
Assembling the flux only on FooService class for readability purposes. Output to be analyzed.

Here is a snippet of the output log:
```
11:38:49.727 [parallel-2] ERROR c.b.d.consumer.service.FooService - Approach 4 failed!
java.lang.ArithmeticException: / by zero
	at com.baeldung.debugging.consumer.service.FooQuantityHelper.divideFooQuantity(FooQuantityHelper.java:20)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:107)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.innerNext(FluxConcatMap.java:271)
	at reactor.core.publisher.FluxConcatMap$ConcatMapInner.onNext(FluxConcatMap.java:803)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1083)
	at reactor.core.publisher.MonoDelayUntil$DelayUntilCoordinator.signal(MonoDelayUntil.java:211)
	at reactor.core.publisher.MonoDelayUntil$DelayUntilTrigger.onComplete(MonoDelayUntil.java:290)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onComplete(FluxOnAssembly.java:460)
	at reactor.core.publisher.MonoDelay$MonoDelayRunnable.run(MonoDelay.java:118)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:50)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:27)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.FluxMapFuseable] :
	reactor.core.publisher.Flux.map(Flux.java:5077)
	com.baeldung.debugging.consumer.service.FooService.processUsingApproachFourWithCheckpoint(FooService.java:63)
	com.baeldung.debugging.consumer.chronjobs.ChronJobs.consumeFiniteFluxWithCheckpoint4(ChronJobs.java:120)
	org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84)
	org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
Error has been observed by the following operator(s):
	|_	Flux.map(FooService.java:63)
	|_	Flux.checkpoint(FooService.java:64)
	|_	Flux.map(FooService.java:65)
	|_	Flux.map(FooService.java:66)
```
And this is the log output when we assembly the flux in different sections of the project:
```
10:48:20.189 [parallel-3] ERROR c.b.d.consumer.service.FooService - Approach 4 failed!
java.lang.ArithmeticException: / by zero
	at com.baeldung.debugging.consumer.service.FooQuantityHelper.lambda$divideFooQuantity$1(FooQuantityHelper.java:25)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:107)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxMapFuseable$MapFuseableSubscriber.onNext(FluxMapFuseable.java:115)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.FluxConcatMap$ConcatMapImmediate.innerNext(FluxConcatMap.java:271)
	at reactor.core.publisher.FluxConcatMap$ConcatMapInner.onNext(FluxConcatMap.java:803)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onNext(FluxOnAssembly.java:450)
	at reactor.core.publisher.Operators$MonoSubscriber.complete(Operators.java:1083)
	at reactor.core.publisher.MonoDelayUntil$DelayUntilCoordinator.signal(MonoDelayUntil.java:211)
	at reactor.core.publisher.MonoDelayUntil$DelayUntilTrigger.onComplete(MonoDelayUntil.java:290)
	at reactor.core.publisher.FluxOnAssembly$OnAssemblySubscriber.onComplete(FluxOnAssembly.java:460)
	at reactor.core.publisher.MonoDelay$MonoDelayRunnable.run(MonoDelay.java:118)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:50)
	at reactor.core.scheduler.SchedulerTask.call(SchedulerTask.java:27)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.FluxMapFuseable] :
	reactor.core.publisher.Flux.map(Flux.java:5077)
	com.baeldung.debugging.consumer.service.FooQuantityHelper.divideFooQuantity(FooQuantityHelper.java:24)
	com.baeldung.debugging.consumer.service.FooService.processUsingApproachFourWithCheckpoint(FooService.java:69)
	com.baeldung.debugging.consumer.chronjobs.ChronJobs.consumeFiniteFluxWithCheckpoint4(ChronJobs.java:120)
	org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84)
	org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)
	java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
Error has been observed by the following operator(s):
	|_	Flux.map(FooQuantityHelper.java:24)
	|_	Flux.checkpoint(FooService.java:70)
	|_	Flux.map(FooReporter.java:15)
	|_	Flux.map(FooNameHelper.java:18)
	|_	Flux.map(FooNameHelper.java:30)
```